### PR TITLE
Start project

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.10" />
+    <option name="version" value="1.9.0" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace = "com.senmonb.vocabify"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
-        applicationId = "com.senmonb.vocabify"
-        minSdk = 24
-        targetSdk = 33
+        applicationId = "com.example.todoAppJpc"
+        minSdk = 26
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
 
@@ -30,17 +30,17 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.0"
     }
     packaging {
         resources {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version "8.1.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.10" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.0" apply false
 }


### PR DESCRIPTION
とりあえずビルドができるように修正
バージョンの部分は[この辺](https://github.com/Ichimura-Riku/todo_app_jpc/blob/main/build.gradle.kts)を参考んにした

### 認識外の対応
"org.jetbrains.kotlin.android"のバージョンでエラーが発生した。これ、ビルド時にこうなっているはずなんで、初期設定でビルドができないのが謎。AndroidStudioのアップデートがあるかもしれないので後で確認する。
今回は回線の影響か、アップデートのチェックができていなかったので、家帰って確認する。
- kotlinのバージョンアップの影響な気がする