### PR TITLE
Create home screen

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+Vocabify

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,41 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/app/src/main/java/com/senmonb/vocabify/MainActivity.kt
+++ b/app/src/main/java/com/senmonb/vocabify/MainActivity.kt
@@ -6,10 +6,8 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import com.senmonb.vocabify.ui.screen.HomeScreen
 import com.senmonb.vocabify.ui.theme.VocabifyTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -24,28 +22,9 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background,
                 ) {
-                    Greeting("Android")
+                    HomeScreen()
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(
-    name: String,
-    modifier: Modifier = Modifier,
-) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier,
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    VocabifyTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/senmonb/vocabify/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/senmonb/vocabify/ui/screen/HomeScreen.kt
@@ -1,0 +1,39 @@
+package com.senmonb.vocabify.ui.screen
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposeCompilerApi
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeScreen(
+    modifier: Modifier = Modifier,
+    viewModel: HomeViewModel = hiltViewModel(),
+) {
+
+    Scaffold { innerPadding ->
+        HomeContainer(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        )
+
+    }
+}
+
+
+@Composable
+fun HomeContainer(
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = "Hello Android!",
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/com/senmonb/vocabify/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/senmonb/vocabify/ui/screen/HomeScreen.kt
@@ -1,12 +1,15 @@
 package com.senmonb.vocabify.ui.screen
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ComposeCompilerApi
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 
@@ -16,7 +19,6 @@ fun HomeScreen(
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
-
     Scaffold { innerPadding ->
         HomeContainer(
             modifier = modifier
@@ -32,8 +34,25 @@ fun HomeScreen(
 fun HomeContainer(
     modifier: Modifier = Modifier,
 ) {
-    Text(
-        text = "Hello Android!",
-        modifier = modifier
-    )
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text("Let's Learn Vocabulary")
+        Column {
+
+            Button(onClick = { /*TODO*/ }) {
+                Text(text = "add Vocabulary")
+            }
+
+            Button(onClick = { /*TODO*/ }) {
+                Text(text = "learning English-Japanese")
+            }
+
+            Button(onClick = { /*TODO*/ }) {
+                Text(text = "learning Japanese-English")
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/senmonb/vocabify/ui/screen/HomeViewModel.kt
+++ b/app/src/main/java/com/senmonb/vocabify/ui/screen/HomeViewModel.kt
@@ -1,0 +1,10 @@
+package com.senmonb.vocabify.ui.screen
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeViewModel @Inject constructor() : ViewModel(){
+
+}


### PR DESCRIPTION
# HomeScreenの仮のレイアウト作成
- HomeScreenのコンポーネント作成
    - home画面のテキスト
    - 各Screenに遷移するためのボタンを配置
　    - onClick入れてない
- HomeViewModel
    - 今の所機能はない
    - Homeにstateを持たせる必要がないなら削除してもいいかも
    - 今の所Hiltを使ってるけど、これも使わないなら削除していいかも
- MainActivity
    - デフォルトのレイアウトを削除  


ちなみに、最初の[コミット](a2a2477df3dbfa4515e38e3f55af66e87369db63)は他ブランチでいじっていたもののhilt関連のファイルに変更が入ったのでコミットとして反映させた