### PR TITLE
fix HomeContainer Layout in HomeScreen.kt

### DIFF
--- a/app/src/main/java/com/senmonb/vocabify/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/senmonb/vocabify/ui/screen/HomeScreen.kt
@@ -47,7 +47,11 @@ fun HomeContainer(
         verticalArrangement = Arrangement.Center,
     ) {
         Text("Let's Learn Vocabulary")
-        Column() {
+        Column(
+            modifier = modifier,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
 
             Button(onClick = { /*TODO*/ }) {
                 Text(text = "add Vocabulary")

--- a/app/src/main/java/com/senmonb/vocabify/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/senmonb/vocabify/ui/screen/HomeScreen.kt
@@ -6,11 +6,20 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.senmonb.vocabify.R
 import com.senmonb.vocabify.ui.navigation.NavigationDestination
@@ -46,9 +55,15 @@ fun HomeContainer(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        Text("Let's Learn Vocabulary")
+        Text(
+            modifier = Modifier.padding(10.dp, 40.dp),
+            text = "Let's Learn Vocabulary", style = LocalTextStyle.current.merge(
+                TextStyle(
+                    fontSize = 25.sp,
+                )
+            )
+        )
         Column(
-            modifier = modifier,
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {


### PR DESCRIPTION
close #11 
# HomeScreenのレイアウトをちょっと修正
- ボタンが右によってたんでを中央に寄せた
- columnをtextのレイアウトのサイズを調整