### PR TITLE
Adjust add vocabulary screen

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+/src/main/java/com/senmonb/vocabify/env.kt

--- a/app/src/main/java/com/senmonb/vocabify/ui/screen/AddVocabularyScreen.kt
+++ b/app/src/main/java/com/senmonb/vocabify/ui/screen/AddVocabularyScreen.kt
@@ -61,7 +61,7 @@ fun AddVocabularyContainer(
             modifier = Modifier.fillMaxWidth(),
             value = inputText,
             onValueChange = setInputText,
-            label = { Text("Input:") }
+            label = { Text("input keyword") }
         )
         Button(
             onClick = {
@@ -69,22 +69,8 @@ fun AddVocabularyContainer(
             },
             modifier = Modifier.padding(8.dp)
         ) {
-            Text("Generate Text")
+            Text("entry")
         }
-        Card(
-            modifier = Modifier
-                .padding(vertical = 2.dp)
-                .fillMaxWidth()
-        ) {
-            Column(
-                modifier = Modifier.padding(8.dp)
-            ) {
-                Text(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = textOutput,
-                    style = MaterialTheme.typography.bodyMedium
-                )
-            }
-        }
+
     }
 }

--- a/app/src/main/java/com/senmonb/vocabify/ui/screen/AddVocabularyScreen.kt
+++ b/app/src/main/java/com/senmonb/vocabify/ui/screen/AddVocabularyScreen.kt
@@ -1,12 +1,24 @@
 package com.senmonb.vocabify.ui.screen
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.senmonb.vocabify.R
 import com.senmonb.vocabify.ui.navigation.NavigationDestination
@@ -28,11 +40,51 @@ fun AddVocabularyScreen(
                 modifier
                     .fillMaxSize()
                     .padding(innerPadding),
+            viewModel = viewModel,
         )
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AddVocabularyContainer(modifier: Modifier = Modifier)  {
-    Text(text = "add vocabulary screen")
+fun AddVocabularyContainer(
+    modifier: Modifier = Modifier,
+    viewModel: AddVocabularyViewModel,
+    )  {
+    val (inputText, setInputText) = remember { mutableStateOf("") }
+    val textOutput: String by viewModel.output.collectAsState()
+    Column(
+        modifier = Modifier.padding(all = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = inputText,
+            onValueChange = setInputText,
+            label = { Text("Input:") }
+        )
+        Button(
+            onClick = {
+                viewModel.sendPrompt(inputText)
+            },
+            modifier = Modifier.padding(8.dp)
+        ) {
+            Text("Generate Text")
+        }
+        Card(
+            modifier = Modifier
+                .padding(vertical = 2.dp)
+                .fillMaxWidth()
+        ) {
+            Column(
+                modifier = Modifier.padding(8.dp)
+            ) {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = textOutput,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/senmonb/vocabify/ui/screen/AddVocabularyViewModel.kt
+++ b/app/src/main/java/com/senmonb/vocabify/ui/screen/AddVocabularyViewModel.kt
@@ -43,7 +43,16 @@ constructor(
         )
     }
 
-    fun sendPrompt(inputTextPrompt: String) {
+    fun sendPrompt(inputText: String) {
+
+        val inputTextPrompt = """
+            Generate several words related to $inputText and their Japanese translations. Output the generated words in the following json format. The Japanese translations should be generated in Japanese.
+            
+              {"id" : "1", "word" : "word1", "translate" : "japanese translation1" },
+              {"id" : "2", "word" : "word2", "translate" : "japanese translation2" },
+              ...
+            
+        """.trimIndent()
         // Create the text prompt
         val prompt = createPrompt(inputTextPrompt)
 

--- a/app/src/main/java/com/senmonb/vocabify/ui/screen/AddVocabularyViewModel.kt
+++ b/app/src/main/java/com/senmonb/vocabify/ui/screen/AddVocabularyViewModel.kt
@@ -1,10 +1,119 @@
 package com.senmonb.vocabify.ui.screen
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.ai.generativelanguage.v1beta3.GenerateTextRequest
+import com.google.ai.generativelanguage.v1beta3.TextPrompt
+import com.google.ai.generativelanguage.v1beta3.TextServiceClient
+import com.google.ai.generativelanguage.v1beta3.TextServiceSettings
+import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider
+import com.google.api.gax.rpc.FixedHeaderProvider
+import com.senmonb.vocabify.PaLM_KEY
+import com.senmonb.vocabify.data.LearnRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class AddVocabularyViewModel
-    @Inject
-    constructor() : ViewModel()
+@Inject
+constructor(
+    savedStateHandle: SavedStateHandle,
+    learnRepository: LearnRepository,
+) : ViewModel() {
+    // UI表示用のstate
+    private val _output = MutableStateFlow(value = "")
+    val output: StateFlow<String>
+        get() = _output
+
+    // リクエスト送信のための変数
+    private var client: TextServiceClient
+
+    // clientの初期化
+    init {
+        // Initialize the Text Service Client
+        client = initializeTextServiceClient(
+            apiKey = PaLM_KEY
+        )
+    }
+
+    fun sendPrompt(inputTextPrompt: String) {
+        // Create the text prompt
+        val prompt = createPrompt(inputTextPrompt)
+
+        // Send the first request
+        val request = createTextRequest(prompt)
+        generateText(request)
+
+    }
+
+    // テキスト サービス クライアントの初期化
+    private fun initializeTextServiceClient(
+        apiKey: String
+    ): TextServiceClient {
+        // (This is a workaround because GAPIC java libraries don't yet support API key auth)
+        val transportChannelProvider = InstantiatingGrpcChannelProvider.newBuilder()
+            .setHeaderProvider(
+                FixedHeaderProvider.create(
+                    hashMapOf(
+                        "x-goog-api-key" to "AIzaSyAIcPo5UiXnjgPwK7c8NbgZ-fz5fhNUlp8"
+                    )
+                )
+            )
+            .build()
+
+        // Create TextServiceSettings
+        val settings = TextServiceSettings.newBuilder()
+            .setTransportChannelProvider(transportChannelProvider)
+            .setCredentialsProvider(FixedCredentialsProvider.create(null))
+            .build()
+
+        // Initialize a TextServiceClient
+        val textServiceClient = TextServiceClient.create(settings)
+
+        return textServiceClient
+    }
+
+    // テキスト プロンプトの作成
+    private fun createPrompt(
+        textContent: String
+    ): TextPrompt {
+        return TextPrompt.newBuilder()
+            .setText(textContent)
+            .build()
+    }
+
+    // テキストを生成
+    private fun createTextRequest(prompt: TextPrompt): GenerateTextRequest {
+        return GenerateTextRequest.newBuilder()
+            .setModel("models/text-bison-001") // Required, which model to use to generate the result
+            .setPrompt(prompt) // Required
+            .setTemperature(0.5f) // Optional, controls the randomness of the output
+            .setCandidateCount(1) // Optional, the number of generated texts to return
+            .build()
+    }
+
+    // リクエスト送信
+
+    private fun generateText(
+        request: GenerateTextRequest
+    ) {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val response = client.generateText(request)
+                val returnedText = response.candidatesList.last()
+                // display the returned text in the UI
+                _output.update { returnedText.output }
+            } catch (e: Exception) {
+                // There was an error, let's add a new text with the details
+                _output.update { "API Error: ${e.message}" }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/senmonb/vocabify/ui/screen/AddVocabularyViewModel.kt
+++ b/app/src/main/java/com/senmonb/vocabify/ui/screen/AddVocabularyViewModel.kt
@@ -1,5 +1,8 @@
 package com.senmonb.vocabify.ui.screen
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -11,6 +14,7 @@ import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider
 import com.google.api.gax.rpc.FixedHeaderProvider
 import com.senmonb.vocabify.PaLM_KEY
+import com.senmonb.vocabify.data.Learn
 import com.senmonb.vocabify.data.LearnRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -25,8 +29,11 @@ class AddVocabularyViewModel
 @Inject
 constructor(
     savedStateHandle: SavedStateHandle,
-    learnRepository: LearnRepository,
+    private val learnRepository: LearnRepository,
 ) : ViewModel() {
+
+    private var learnUiState by mutableStateOf(LearnUiState())
+
     // UI表示用のstate
     private val _output = MutableStateFlow(value = "")
     val output: StateFlow<String>
@@ -125,4 +132,40 @@ constructor(
             }
         }
     }
+
+    suspend fun insertLearn() {
+        //  viewModelScope.launch{}
+        learnRepository.insertLearn(learnUiState.learnState.toLearn())
+    }
 }
+
+data class LearnUiState(
+    val learnState: LearnState = LearnState(),
+
+    )
+
+data class LearnState(
+    val id: Int = 0,
+    val word: String = "",
+    val translation: String = "",
+    val isLook: Boolean = false
+)
+
+
+fun LearnState.toLearn(): Learn = Learn(
+    id = 0,
+    word = "",
+    translation = "",
+    isLook = if (isLook) 1 else 0
+)
+
+fun Learn.toLearnUiState(): LearnUiState = LearnUiState(
+    learnState = this.toLearnState(),
+)
+
+fun Learn.toLearnState(): LearnState = LearnState(
+    id = 0,
+    word = "",
+    translation = "",
+    isLook = isLook == 1
+)


### PR DESCRIPTION
# 追加画面の必要最小限の画面を作成
- 追加用のviewModel準備
    - json変換用のdata classとかも定義
    - apiKeyはenvファイルで実装
    - apiにはjsonで返すように入力
- Screenの作成
    - TextFieldは関連キーワードを入れる
    - 一旦取得した文字を消したけど、写せたら多分凄そうに見えると思うんで、余裕があったらListViewで写したい
 
カラムにCategoryを入れて、過去の学習内容を一覧で見れるようにしたかったが、正規化するroomの実装を知らないので時間の関係上今回は単一のキーワードのデータのみ保存することにした。